### PR TITLE
Fixed a very easy and stupid duplication bug

### DIFF
--- a/src/main/java/fox/spiteful/avaritia/gui/ContainerCompressor.java
+++ b/src/main/java/fox/spiteful/avaritia/gui/ContainerCompressor.java
@@ -69,7 +69,7 @@ public class ContainerCompressor extends Container {
                         return null;
                     }
                 }
-                else if (slotNumber >= 3 && slotNumber < 30)
+                else if (slotNumber >= 2 && slotNumber < 29)
                 {
                     if (!this.mergeItemStack(itemstack1, 29, 38, false))
                     {


### PR DESCRIPTION
Steps to reproduce:
1. Open Compressor GUI
2. Place any item to 1st hotbar slot
3. Leave 2nd slot blank and fill slots 3-9 with any other items
4. Point your cursor on 1st slot and click Shift+LMB
5. Item from first slot will been moved to second slot and their stack size will been increased twice