### PR TITLE
Update neutronium name

### DIFF
--- a/src/main/resources/assets/avaritia/lang/en_US.lang
+++ b/src/main/resources/assets/avaritia/lang/en_US.lang
@@ -2,9 +2,9 @@
 # Items
 item.avaritia_resource.diamond_lattice.name=Diamond Lattice
 item.avaritia_resource.crystal_matrix_ingot.name=Crystal Matrix Ingot
-item.avaritia_resource.neutron_pile.name=Pile of Neutrons
-item.avaritia_resource.neutron_nugget.name=Neutronium Nugget
-item.avaritia_resource.neutronium_ingot.name=Neutronium Ingot
+item.avaritia_resource.neutron_pile.name=Pile of Cosmic Neutrons
+item.avaritia_resource.neutron_nugget.name=Cosmic Neutronium Nugget
+item.avaritia_resource.neutronium_ingot.name=Cosmic Neutronium Ingot
 item.avaritia_resource.infinity_catalyst.name=Infinity Catalyst
 item.avaritia_resource.infinity_ingot.name=Infinity Ingot
 item.avaritia_resource.record_fragment.name=Record Fragment


### PR DESCRIPTION
This puts it in line with the ore dictionary name and the GT dust that is currently in use. Makes logical sense imo as currently we have two ingots named neutronium as well as inconsistency between the dust and ingot.