### PR TITLE
Add missing markDirty() calls on inventory slot changes

### DIFF
--- a/src/main/java/fox/spiteful/avaritia/tile/TileEntityDireCrafting.java
+++ b/src/main/java/fox/spiteful/avaritia/tile/TileEntityDireCrafting.java
@@ -75,9 +75,11 @@ public class TileEntityDireCrafting extends TileLudicrous implements IInventory,
                 if(result.stackSize <= decrement) {
                     ItemStack craft = result;
                     result = null;
+                    markDirty();
                     return craft;
                 }
                 ItemStack split = result.splitStack(decrement);
+                markDirty();
                 if(result.stackSize <= 0)
                     result = null;
                 return split;
@@ -90,9 +92,11 @@ public class TileEntityDireCrafting extends TileLudicrous implements IInventory,
                 if(matrix[slot - 1].stackSize <= decrement){
                     ItemStack ingredient = matrix[slot - 1];
                     matrix[slot - 1] = null;
+                    markDirty();
                     return ingredient;
                 }
                 ItemStack split = matrix[slot - 1].splitStack(decrement);
+                markDirty();
                 if(matrix[slot - 1].stackSize <= 0)
                     matrix[slot - 1] = null;
                 return split;
@@ -127,9 +131,11 @@ public class TileEntityDireCrafting extends TileLudicrous implements IInventory,
     public void setInventorySlotContents(int slot, ItemStack stack){
         if(slot == 0){
             result = stack;
+            markDirty();
         }
         else if(slot <= matrix.length){
             matrix[slot - 1] = stack;
+            markDirty();
         }
     }
 

--- a/src/main/java/fox/spiteful/avaritia/tile/TileEntityNeutron.java
+++ b/src/main/java/fox/spiteful/avaritia/tile/TileEntityNeutron.java
@@ -75,11 +75,13 @@ public class TileEntityNeutron extends TileLudicrous implements IInventory {
                 ItemStack take = neutrons.splitStack(decrement);
                 if(neutrons.stackSize <= 0)
                     neutrons = null;
+                markDirty();
                 return take;
             }
             else {
                 ItemStack take = neutrons;
                 neutrons = null;
+                markDirty();
                 return take;
             }
         }


### PR DESCRIPTION
Similarly to the previous PRs for storage drawers and gt5u, based on reports on discord I was able to find that the dire crafting table also didn't call markDirty, which could lead to dupes/missing items