### PR TITLE
Minor star fuel changes

### DIFF
--- a/src/main/java/fox/spiteful/avaritia/crafting/Grinder.java
+++ b/src/main/java/fox/spiteful/avaritia/crafting/Grinder.java
@@ -136,16 +136,6 @@ public class Grinder {
                 "C",
                 'C',
                 new ItemStack(LudicrousBlocks.resource_block, 1, 1));
-
-        GameRegistry.addShapedRecipe(
-                new ItemStack(LudicrousItems.resource, 13, 8),
-                "CCC",
-                "CIC",
-                "CCC",
-                'C',
-                new ItemStack(Blocks.coal_block, 1),
-                'I',
-                new ItemStack(LudicrousItems.resource, 1, 1));
         GameRegistry.addShapedRecipe(
                 new ItemStack(LudicrousItems.resource, 1, 9),
                 " I ",

--- a/src/main/java/fox/spiteful/avaritia/items/ItemResource.java
+++ b/src/main/java/fox/spiteful/avaritia/items/ItemResource.java
@@ -55,7 +55,7 @@ public class ItemResource extends Item implements IHaloRenderItem {
     public void addInformation(ItemStack item, EntityPlayer player, List<String> tooltip, boolean wut) {
 
         int meta = item.getItemDamage();
-        if (meta != 0 && meta < 8) {
+        if (meta != 0 && meta < 9) {
             tooltip.add(
                     EnumChatFormatting.DARK_GRAY + ""
                             + EnumChatFormatting.ITALIC


### PR DESCRIPTION
This PR removes the crafting table recipe of the currently useless star fuel item and restores its tooltip which wasnt showing due to a bug. These changes are in preparation for the godforge multiblock, as it is intended to use this item as fuel (it will get a new recipe in coremod).