### PR TITLE
Reduce direct buffer allocations

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,30 +1,30 @@
 // Add your dependencies here
 
 dependencies {
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.42-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.46-GTNH:dev")
 
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.16:api") {
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.19:api") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:Botania:1.11.5-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:Mantle:0.4.1:dev") {
+    compileOnly("com.github.GTNewHorizons:Mantle:0.4.2:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.12-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.16-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.6.6:dev") {
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.6.9:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.0:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.71:dev") {
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.81:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.38:dev") {
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.78:dev") {
         transitive = false
     }
 
@@ -41,5 +41,5 @@ dependencies {
         transitive = false
     }
 
-    runtimeOnly("com.github.GTNewHorizons:GTNHLib:0.5.14:dev")
+    runtimeOnly("com.github.GTNewHorizons:GTNHLib:0.5.20:dev")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
 }
 
 

--- a/src/main/java/fox/spiteful/avaritia/render/LudicrousRenderEvents.java
+++ b/src/main/java/fox/spiteful/avaritia/render/LudicrousRenderEvents.java
@@ -64,7 +64,8 @@ public class LudicrousRenderEvents {
     public void pushTheCosmicFancinessToTheLimit(RenderTickEvent event) {
         if (event.phase == Phase.START) {
             for (IIcon icon : cosmicIcons) {
-                if (Avaritia.isHodgepodgeLoaded && icon instanceof IPatchedTextureAtlasSprite patchedTextureAtlasSprite) {
+                if (Avaritia.isHodgepodgeLoaded
+                        && icon instanceof IPatchedTextureAtlasSprite patchedTextureAtlasSprite) {
                     patchedTextureAtlasSprite.markNeedsAnimationUpdate();
                 }
                 cosmicUVs.put(icon.getMinU());

--- a/src/main/java/fox/spiteful/avaritia/render/LudicrousRenderEvents.java
+++ b/src/main/java/fox/spiteful/avaritia/render/LudicrousRenderEvents.java
@@ -19,7 +19,7 @@ import fox.spiteful.avaritia.Avaritia;
 public class LudicrousRenderEvents {
 
     private static final int cosmicCount = 10;
-    public static String[] cosmicTextures = new String[cosmicCount];
+    public static final String[] cosmicTextures = new String[cosmicCount];
 
     static {
         for (int i = 0; i < cosmicCount; i++) {
@@ -27,8 +27,8 @@ public class LudicrousRenderEvents {
         }
     }
 
-    public static FloatBuffer cosmicUVs = BufferUtils.createFloatBuffer(4 * cosmicTextures.length);
-    public static IIcon[] cosmicIcons = new IIcon[cosmicTextures.length];
+    public static final FloatBuffer cosmicUVs = BufferUtils.createFloatBuffer(4 * cosmicTextures.length);
+    public static final IIcon[] cosmicIcons = new IIcon[cosmicTextures.length];
 
     @SubscribeEvent
     public void letsMakeAQuilt(TextureStitchEvent.Pre event) {
@@ -63,10 +63,9 @@ public class LudicrousRenderEvents {
     @SubscribeEvent
     public void pushTheCosmicFancinessToTheLimit(RenderTickEvent event) {
         if (event.phase == Phase.START) {
-            cosmicUVs = BufferUtils.createFloatBuffer(4 * cosmicIcons.length);
             for (IIcon icon : cosmicIcons) {
-                if (Avaritia.isHodgepodgeLoaded && icon instanceof IPatchedTextureAtlasSprite) {
-                    ((IPatchedTextureAtlasSprite) icon).markNeedsAnimationUpdate();
+                if (Avaritia.isHodgepodgeLoaded && icon instanceof IPatchedTextureAtlasSprite patchedTextureAtlasSprite) {
+                    patchedTextureAtlasSprite.markNeedsAnimationUpdate();
                 }
                 cosmicUVs.put(icon.getMinU());
                 cosmicUVs.put(icon.getMinV());


### PR DESCRIPTION
Avaritia was creating a new float buffer every tick when only one was needed.