### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/avaritia/lang/en_US.lang
+++ b/src/main/resources/assets/avaritia/lang/en_US.lang
@@ -1,5 +1,6 @@
 #
 # Items
+item.avaritia_resource.name=Resource
 item.avaritia_resource.diamond_lattice.name=Diamond Lattice
 item.avaritia_resource.crystal_matrix_ingot.name=Crystal Matrix Ingot
 item.avaritia_resource.neutron_pile.name=Pile of Cosmic Neutrons
@@ -10,6 +11,7 @@ item.avaritia_resource.infinity_ingot.name=Infinity Ingot
 item.avaritia_resource.record_fragment.name=Record Fragment
 item.avaritia_resource.starfuel.name=Star Fuel
 item.avaritia_resource.neutronium_gear.name=Neutronium Gear
+item.avaritia_singularity.name=Singularity
 item.singularity_iron.name=Iron Singularity
 item.singularity_gold.name=Golden Singularity
 item.singularity_lapis.name=Lapis Singularity
@@ -51,6 +53,7 @@ item.extremely_primordial_pearl.name=Extremely Primordial Pearl
 # Blocks
 tile.compressed_workbench.name=Compressed Crafting Table
 tile.very_compressed_workbench.name=Double Compressed Crafting Table
+tile.avaritia_resource.name=Resource Block
 tile.block_crystal_matrix.name=Crystal Matrix
 tile.block_neutronium.name=Cosmic Neutronium Block
 tile.block_infinity.name=Infinity Block


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.