### PR TITLE
Add a comment warning about a variable that uses loader checks

### DIFF
--- a/src/main/java/fox/spiteful/avaritia/compat/Compat.java
+++ b/src/main/java/fox/spiteful/avaritia/compat/Compat.java
@@ -51,6 +51,8 @@ public class Compat {
         ae2 = Loader.isModLoaded("appliedenergistics2") && Config.ae2;
         exu = Loader.isModLoaded("ExtraUtilities") && Config.exu;
         ic2 = Loader.isModLoaded("IC2") && Config.ic2;
+        // NOTE: This will only work with gt5 unless you add ` && !Loader.isModLoaded("gregapi")`.
+        // This doesn't cause errors with gt6 now, but it might if anyone plans on using it specifically as a *gt5* check
         gt = Loader.isModLoaded("gregtech") && Config.gt;
         botan = Loader.isModLoaded("Botania") && Config.botan;
         blood = Loader.isModLoaded("AWWayofTime") && Config.blood;


### PR DESCRIPTION
If the "gt" variable is to be used as specifically a GT5 check, then add the extra loader check suggested. This PR doesn't touch any of the Optional decorators that currently crash with gt6